### PR TITLE
AT-46966 - increased loadUrlTimeoutValue

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -20,6 +20,7 @@
     <preference name="SplashScreen" value="screen" />
     <preference name="SplashScreenDelay" value="3000" />
     <preference name="CordovaWebViewEngine" value="CDVUIWebViewEngine" />
+    <preference name="loadUrlTimeoutValue" value="700000" />
     <platform name="android">
         <allow-intent href="market:*" />
         <icon density="ldpi" src="resources/android/icon/drawable-ldpi-icon.png" />


### PR DESCRIPTION
This might solve "The connection to the server was unsuccessful. (file:///android_asset/www/index.html)" on app startup.